### PR TITLE
Switch repo sync action

### DIFF
--- a/.github/workflows/fork_sync.yml
+++ b/.github/workflows/fork_sync.yml
@@ -1,21 +1,46 @@
 name: Sync Fork
 on:
   push:
-  workflow_dispatch:
+    branches: [ master ]
   schedule:
     - cron: '0 * * * *'
+  workflow_dispatch:  # click the button on Github repo!
+    inputs:
+      sync_test_mode: # Adds a boolean option that appears during manual workflow run for easy test mode config
+        description: 'Fork Sync Test Mode'
+        type: boolean
+        default: false
 
 jobs:
-  sync_fork:
+  sync_latest_from_upstream:
     runs-on: ubuntu-latest
+    name: Sync latest commits from upstream repo
+
     steps:
-      - uses: tgymnich/fork-sync@v1.9
-        with:
-          owner: Windows200000
-          repo: TwitchDropsMiner-updated
-          base: master
-          head: master
-          retries: 1
-          retry_after: 10
-          ignore_fail: true
-          token: ${{ secrets.PERSONAL_TOKEN }}
+    - name: Checkout target repo
+      uses: actions/checkout@v4
+      with:
+        ref:  master
+
+    - name: Sync upstream changes
+      id: sync
+      uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
+      with:
+        target_sync_branch: master
+        # REQUIRED 'target_repo_token' exactly like this!
+        target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+        upstream_sync_branch: master
+        upstream_sync_repo: Windows200000/TwitchDropsMiner-updated
+        # Set test_mode true during manual dispatch to run tests instead of the true action!!
+        test_mode: ${{ inputs.sync_test_mode }}
+
+    - name: New commits found
+      if: steps.sync.outputs.has_new_commits == 'true'
+      run: echo "New commits were found to sync."
+
+    - name: No new commits
+      if: steps.sync.outputs.has_new_commits == 'false'
+      run: echo "There were no new commits."
+
+    - name: Show value of 'has_new_commits'
+      run: echo ${{ steps.sync.outputs.has_new_commits }}


### PR DESCRIPTION
Previous changes to the sync action I made were incorrect.
It appears that `tgymnich/fork-sync` doesn't support changing the source repo.

I couldn't find another action that opens PRs, but `aormsby/Fork-Sync-With-Upstream-action` seems the closest I could find. 
It'll just fail if there are conflicts, though.


Alternatively, @Valentin-Metz can ask GitHub support to "reroute" the fork
https://support.github.com/request/fork