### PR TITLE
bump Dockerfile python to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-bullseye
+FROM python:3.10-bullseye
 
 # Install xvfb - a virtual X display server for the GUI to display to
 RUN apt-get update && apt-get upgrade -y


### PR DESCRIPTION
The current image errors with the following because match is only in python >= 3.10:

Traceback (most recent call last):                                                            
  File "/TwitchDropsMiner/main.py", line 28, in <module>                                          from twitch import Twitch                                                                 
  File "/TwitchDropsMiner/twitch.py", line 39, in <module>                                        from gui import GUIManager                                                                  File "/TwitchDropsMiner/gui.py", line 2202                                                  
    match name:                                
          ^                                    
SyntaxError: invalid syntax